### PR TITLE
Replace model[varname] subscript lookup with attribute access

### DIFF
--- a/gpkitmodels/GP/aircraft/engine/df70.py
+++ b/gpkitmodels/GP/aircraft/engine/df70.py
@@ -23,22 +23,21 @@ class DF70(Model):
 class DF70Perf(Model):
     "engine performance model"
 
+    P_shaft = Var("hp", "Shaft power")
+    BSFC = Var("kg/kW/hr", "Brake specific fuel consumption")
+    P_avn = Var("watts", "Avionics power", value=40)
+    P_total = Var("hp", "Total power, avionics included")
+    eta_alternator = Var("-", "alternator efficiency", value=0.8)
+
     def setup(self, static, state):
 
-        Pshaft = Variable("P_{shaft}", "hp", "Shaft power")
-        bsfc = Variable("BSFC", "kg/kW/hr", "Brake specific fuel consumption")
-        Pavn = Variable("P_{avn}", 40, "watts", "Avionics power")
-        Ptotal = Variable("P_{total}", "hp", "Total power, avionics included")
-        eta_alternator = Variable(
-            "\\eta_{alternator}", 0.8, "-", "alternator efficiency"
-        )
         href_val = 1000  # shared with Variable below to stay in sync
         href = Variable("h_{ref}", href_val, "ft", "reference altitude")  # noqa: F841
         h_vals = state.substitutions["h"]
         if not hasattr(h_vals, "__len__"):
             h_vals = [h_vals]
         # L_eng = 1 - 0.035*h/h_ref (signomial, must pre-compute as constant)
-        h_units = state["h"].key.units  # pint Quantity, e.g. "1 foot"
+        h_units = state.h.key.units  # pint Quantity, e.g. "1 foot"
         lfac = [
             (-0.035 * v * h_units / (href_val * h_units)).to("").magnitude + 1.0
             for v in h_vals
@@ -50,16 +49,16 @@ class DF70Perf(Model):
         rpm_max = Variable("RPM_{max}", 7698, "rpm", "Maximum RPM")
 
         constraints = [
-            (bsfc / mfac / static.bsfc_min) ** 36.2209
+            (self.BSFC / mfac / static.bsfc_min) ** 36.2209
             >= (
                 2.31541 * (rpm / rpm_max) ** 8.06517
                 + 0.00103364 * (rpm / rpm_max) ** -38.8545
             ),
-            (Ptotal / Pshaftmax) ** 0.1 == 0.999495 * (rpm / rpm_max) ** 0.294421,
+            (self.P_total / Pshaftmax) ** 0.1 == 0.999495 * (rpm / rpm_max) ** 0.294421,
             rpm <= rpm_max,
             Pshaftmax / static.P_sl_max == Leng,
-            Pshaftmax >= Ptotal,
-            Ptotal >= Pshaft + Pavn / eta_alternator,
+            Pshaftmax >= self.P_total,
+            self.P_total >= self.P_shaft + self.P_avn / self.eta_alternator,
         ]
 
         return constraints

--- a/gpkitmodels/GP/aircraft/engine/gas_engine.py
+++ b/gpkitmodels/GP/aircraft/engine/gas_engine.py
@@ -41,21 +41,20 @@ class Engine(Model):
 class EnginePerf(Model):
     "engine performance model"
 
+    P_shaft = Var("hp", "Shaft power")
+    BSFC = Var("kg/kW/hr", "Brake specific fuel consumption")
+    P_avn = Var("watts", "Avionics power", value=40)
+    P_total = Var("hp", "Total power, avionics included")
+    eta_alternator = Var("-", "alternator efficiency", value=0.8)
+
     def setup(self, static, state):
 
-        Pshaft = Variable("P_{shaft}", "hp", "Shaft power")
-        bsfc = Variable("BSFC", "kg/kW/hr", "Brake specific fuel consumption")
-        Pavn = Variable("P_{avn}", 40, "watts", "Avionics power")
-        Ptotal = Variable("P_{total}", "hp", "Total power, avionics included")
-        eta_alternator = Variable(
-            "\\eta_{alternator}", 0.8, "-", "alternator efficiency"
-        )
         href_val = 1000  # shared with Variable below to stay in sync
         href = Variable("h_{ref}", href_val, "ft", "reference altitude")  # noqa: F841
         h_vals = state.substitutions["h"]
         if not hasattr(h_vals, "__len__"):
             h_vals = [h_vals]
-        h_units = state["h"].key.units
+        h_units = state.h.key.units
         lfac = [
             (-0.035 * v * h_units / (href_val * h_units)).to("").magnitude + 1.0
             for v in h_vals
@@ -70,10 +69,10 @@ class EnginePerf(Model):
         ]
 
         constraints = [
-            FitCS(df, bsfc / mfac / static.bsfc_min, [Ptotal / Pshaftmax]),
+            FitCS(df, self.BSFC / mfac / static.bsfc_min, [self.P_total / Pshaftmax]),
             Pshaftmax / static.P_sl_max == Leng,
-            Pshaftmax >= Ptotal,
-            Ptotal >= Pshaft + Pavn / eta_alternator,
+            Pshaftmax >= self.P_total,
+            self.P_total >= self.P_shaft + self.P_avn / self.eta_alternator,
         ]
 
         return constraints

--- a/gpkitmodels/GP/aircraft/fuselage/cylindrical_fuselage.py
+++ b/gpkitmodels/GP/aircraft/fuselage/cylindrical_fuselage.py
@@ -79,7 +79,7 @@ class FuselageAero(Model):
 
     def setup(self, static, state):
         constraints = [
-            self.Re == state["V"] * state["\\rho"] * static.l / state["\\mu"],
+            self.Re == state.V * state.rho * static.l / state.mu,
             self.Cf >= 0.455 / self.Re**0.3,
             self.Cf_ref == 0.455 / self.Re_ref**0.3,
             self.Cd**0.996232

--- a/gpkitmodels/GP/aircraft/mission/breguet_endurance.py
+++ b/gpkitmodels/GP/aircraft/mission/breguet_endurance.py
@@ -21,15 +21,14 @@ class BreguetEndurance(Model):
                 [
                     self.z_bre
                     >= (
-                        perf["P_{total}"]
+                        perf.engine.P_total
                         * self.t
-                        * perf["BSFC"]
+                        * perf.engine.BSFC
                         * g
-                        / (perf["W_{end}"] * perf["W_{start}"]) ** 0.5
+                        / (perf.Wend * perf.Wstart) ** 0.5
                     )
                 ]
             ),
-            self.f_fueloil * self.W_fuel / perf["W_{end}"]
-            >= te_exp_minus1(self.z_bre, 3),
-            perf["W_{start}"] >= perf["W_{end}"] + self.W_fuel,
+            self.f_fueloil * self.W_fuel / perf.Wend >= te_exp_minus1(self.z_bre, 3),
+            perf.Wstart >= perf.Wend + self.W_fuel,
         ]

--- a/gpkitmodels/GP/aircraft/tail/horizontal_tail.py
+++ b/gpkitmodels/GP/aircraft/tail/horizontal_tail.py
@@ -31,4 +31,4 @@ class HorizontalTail(Wing):
                 {self.foam.Abar: 0.0548, self.foam.material.rho: 0.024}
             )
 
-        return self.ascs, self.mh * (1 + 2.0 / self.planform["AR"]) <= 2 * np.pi
+        return self.ascs, self.mh * (1 + 2.0 / self.planform.AR) <= 2 * np.pi

--- a/gpkitmodels/GP/aircraft/tail/tail_boom.py
+++ b/gpkitmodels/GP/aircraft/tail/tail_boom.py
@@ -96,11 +96,11 @@ class TailBoomBending(Model):
         constraints = [
             beam.dx == deta,
             self.F >= qne * S,
-            beam["\\bar{EI}"] <= E * I / self.F / l**2 / 2,
-            Mr >= beam["\\bar{M}"][:-1] * self.F * l,
+            beam.EIbar <= E * I / self.F / l**2 / 2,
+            Mr >= beam.get_var("\\bar{M}")[:-1] * self.F * l,
             sigma >= Mr / Sy,
-            self.th == beam["\\theta"][-1],
-            beam["\\bar{\\delta}"][-1] * CLmax * self.Nsafety <= self.kappa,
+            self.th == beam.get_var("\\theta")[-1],
+            beam.get_var("\\bar{\\delta}")[-1] * CLmax * self.Nsafety <= self.kappa,
         ]
 
         self.tailboomJ = hasattr(tailboom, "J")

--- a/gpkitmodels/GP/aircraft/tail/tail_tests.py
+++ b/gpkitmodels/GP/aircraft/tail/tail_tests.py
@@ -110,7 +110,7 @@ def test_emp():
                 "\\bar{\\delta}_{root}",
                 "\\theta_{root}",
             ]:
-                m.substitutions[l[v]] = 1e-3
+                m.substitutions[l.beam.get_var(v)] = 1e-3
 
     sol = m.solve(verbosity=0, use_leqs=False)  # cvxopt gets singular with leqs
     assert sol.cost == pytest.approx(0.011135, rel=1e-2)
@@ -176,7 +176,7 @@ def test_tailboom_mod():
                 "\\bar{\\delta}_{root}",
                 "\\theta_{root}",
             ]:
-                m.substitutions[l[v]] = 1e-3
+                m.substitutions[l.beam.get_var(v)] = 1e-3
 
     sol = m.solve(verbosity=0)
     assert sol.cost == pytest.approx(0.011294, rel=1e-2)

--- a/gpkitmodels/GP/aircraft/wing/wing.py
+++ b/gpkitmodels/GP/aircraft/wing/wing.py
@@ -136,6 +136,9 @@ class Wing(Model):
     def setup(self, N=5):
         self.N = N
         self.planform = Planform(N)
+        # Convenience aliases for common planform variables
+        self.S = self.planform.S
+        self.b = self.planform.b
         self.components = []
 
         if self.skin_model:
@@ -149,6 +152,6 @@ class Wing(Model):
             self.foam = self.fill_model(self.planform)
             self.components.extend([self.foam])
 
-        constraints = [self.W / self.mfac >= sum(c["W"] for c in self.components)]
+        constraints = [self.W / self.mfac >= sum(c.W for c in self.components)]
 
         return constraints, self.planform, self.components

--- a/gpkitmodels/GP/aircraft/wing/wing_test.py
+++ b/gpkitmodels/GP/aircraft/wing/wing_test.py
@@ -92,7 +92,7 @@ def box_spar():
             loading,
         ],
     )
-    sol = m.solve(verbosity=0)
+    sol = m.solve(verbosity=0, options={"maxiters": 200})
     assert sol.cost == pytest.approx(0.007166, rel=1e-2)
 
 

--- a/gpkitmodels/SP/aircraft/wing/wing.py
+++ b/gpkitmodels/SP/aircraft/wing/wing.py
@@ -16,6 +16,6 @@ class Wing(WingGP):
     def setup(self, N=5):
         self.wing = WingGP.setup(self, N=N)
         with SignomialsEnabled():
-            constraints = [self.mw * (1 + 2 / self.planform["AR"]) >= 2 * np.pi]
+            constraints = [self.mw * (1 + 2 / self.planform.AR) >= 2 * np.pi]
 
         return self.wing, constraints

--- a/gpkitmodels/spacecraft/propulsion.py
+++ b/gpkitmodels/spacecraft/propulsion.py
@@ -7,7 +7,7 @@ This module provides models for analyzing rocket propulsion systems, including:
 - Performance analysis
 """
 
-from gpkit import Variable, units
+from gpkit import Var, units
 from gpkit.tools import te_exp_minus1
 
 from .. import PerformanceModel
@@ -23,13 +23,11 @@ class Burn(PerformanceModel):
         deltav: Variable for the required delta-V
     """
 
+    m_prop = Var("kg", "propellant mass")
+    m_co = Var("kg", "mass at cutoff")
+
     def setup(self, stage, deltav):
         """See class docstring for parameter documentation."""
         g = 9.81 * units("m/s^2")
 
-        m_prop = Variable("m_prop", "kg", "propellant mass")
-        m_co = Variable("m_co", "kg", "mass at cutoff")
-
-        constraints = [m_prop / m_co >= te_exp_minus1(deltav / g / stage["ISP"], 3)]
-
-        return constraints
+        return [self.m_prop / self.m_co >= te_exp_minus1(deltav / g / stage.ISP, 3)]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,9 +1,12 @@
 """Catalog-driven smoke test for gpkit-models."""
 
+import importlib
 from pathlib import Path
 
 import pytest
+from gpkit import Model
 from gpkit.tests.test_catalog import catalog_ids, load_catalog, run_catalog_test
+from gpkit.tests.test_ir import ir_diff
 
 _CATALOG = load_catalog(Path(__file__))
 
@@ -11,3 +14,16 @@ _CATALOG = load_catalog(Path(__file__))
 @pytest.mark.parametrize("model_entry", _CATALOG, ids=catalog_ids(_CATALOG))
 def test_catalog_model(model_entry):
     run_catalog_test(model_entry)
+
+
+@pytest.mark.parametrize("model_entry", _CATALOG, ids=catalog_ids(_CATALOG))
+def test_catalog_ir_roundtrip(model_entry):
+    """gpkit-models catalog model: IR must be identical after round-trip."""
+    mod = importlib.import_module(model_entry["module"])
+    cls = getattr(mod, model_entry["class"])
+    m = cls.default()
+    ir1 = m.to_ir()
+    m2 = Model.from_ir(ir1)
+    ir2 = m2.to_ir()
+    diff = ir_diff(ir1, ir2)
+    assert diff is None, f"{cls.__name__} IR changed after round-trip:\n{diff}"

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -9,7 +9,7 @@ from gpkit.tests.test_catalog import catalog_ids, load_catalog, run_catalog_test
 
 try:
     from gpkit.tests.test_ir import ir_diff
-except ImportError:
+except (ImportError, FileNotFoundError):
     ir_diff = None
 
 _CATALOG = load_catalog(Path(__file__))

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -6,7 +6,11 @@ from pathlib import Path
 import pytest
 from gpkit import Model
 from gpkit.tests.test_catalog import catalog_ids, load_catalog, run_catalog_test
-from gpkit.tests.test_ir import ir_diff
+
+try:
+    from gpkit.tests.test_ir import ir_diff
+except ImportError:
+    ir_diff = None
 
 _CATALOG = load_catalog(Path(__file__))
 
@@ -19,6 +23,8 @@ def test_catalog_model(model_entry):
 @pytest.mark.parametrize("model_entry", _CATALOG, ids=catalog_ids(_CATALOG))
 def test_catalog_ir_roundtrip(model_entry):
     """gpkit-models catalog model: IR must be identical after round-trip."""
+    if ir_diff is None:
+        pytest.skip("ir_diff not available (install gpkit-core from source)")
     mod = importlib.import_module(model_entry["module"])
     cls = getattr(mod, model_entry["class"])
     m = cls.default()


### PR DESCRIPTION
## Summary

- Migrates all `model["varname"]` variable lookups to attribute access (`model.varname`) throughout the aircraft, spacecraft, and tail models
- Drops `Model.__getitem__` for variable lookup, aligning with the attribute-based access pattern
- Adds a catalog IR round-trip test to gpkit-models; handles graceful import fallback when `gpkit-core` is installed from PyPI (no `ir_diff` available)
- Bumps `maxiters` on numerically harder box spar test to avoid non-deterministic CI failures (different iteration counts between macOS/Linux BLAS backends)

## Test plan
- [ ] `uv run pytest -v` passes locally
- [ ] CI passes on Python 3.11 and 3.13
- [ ] Catalog IR round-trip test runs when `ir_diff` is available, skips gracefully otherwise