### PR TITLE
Migrate lint stack to ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203,E741,F821
-per-file-ignores =
-    gpkitmodels/SP/atmosphere/atmosphere.py: E501
-    gpkitmodels/SP/SimPleAC/SimPleAC_mission.py: F841
-    gpkitmodels/GP/aircraft/fuselage/fuselage_profile_drag/fusedragfit.py: F841
-    gpkitmodels/GP/aircraft/tail/empennage.py: E501

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,11 +28,6 @@ jobs:
     - name: Check for file changes
       run: |
         make check-clean
-
-#    - name: Lint with pylint
-#      run: |
-#        uv run pylint gpkitmodels
-#
-#    - name: Check with flake8
-#      run: |
-#        make lint
+    - name: Lint
+      run: |
+        make lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,14 @@
 repos:
   - repo: local
     hooks:
-      - id: isort
-        name: isort
-        entry: uv run isort
+      - id: ruff-check
+        name: ruff check
+        entry: uv run ruff check --fix
         language: system
         types: [python]
 
-      - id: black
-        name: black
-        entry: uv run black
-        language: system
-        types: [python]
-
-      - id: flake8
-        name: flake8
-        entry: uv run flake8
+      - id: ruff-format
+        name: ruff format
+        entry: uv run ruff format
         language: system
         types: [python]

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@
 
 # Code quality
 lint:
-	uv run flake8 gpkitmodels
+	uv run ruff check gpkitmodels
 
 # Code formatting
 format:
-	uv run isort gpkitmodels
-	uv run black gpkitmodels
+	uv run ruff format gpkitmodels
+	uv run ruff check --select I --fix gpkitmodels
 
 # Testing
 test:  # Run tests with pytest
@@ -36,8 +36,8 @@ check-clean:
 # Help
 help:
 	@echo "Available commands:"
-	@echo "  lint              Run fast lint checks"
-	@echo "  format            Format code with isort and black"
+	@echo "  lint              Run lint checks"
+	@echo "  format            Format code with ruff"
 	@echo "  test              Run tests with pytest"
 	@echo "  coverage          Run tests with coverage reporting"
 	@echo "  clean             Clean build artifacts"

--- a/gpkitmodels/GP/aircraft/motor/motor.py
+++ b/gpkitmodels/GP/aircraft/motor/motor.py
@@ -21,7 +21,7 @@ class MotorPerf(Model):
     i = Var("amp", "current")
     v = Var("V", "voltage")
 
-    def setup(self, static, state):
+    def setup(self, static, state):  # noqa: ARG002
         Kv = static.Kv
         R = static.R
         i0 = static.i0

--- a/gpkitmodels/GP/aircraft/tail/empennage.py
+++ b/gpkitmodels/GP/aircraft/tail/empennage.py
@@ -6,8 +6,6 @@ from .horizontal_tail import HorizontalTail
 from .tail_boom import TailBoom
 from .vertical_tail import VerticalTail
 
-# pylint: disable=invalid-name
-
 
 class Empennage(Model):
     "empennage model, consisting of vertical, horizontal and tailboom"

--- a/gpkitmodels/GP/aircraft/tail/tail_boom.py
+++ b/gpkitmodels/GP/aircraft/tail/tail_boom.py
@@ -8,8 +8,6 @@ from gpkitmodels.GP.beam.beam import Beam
 
 from .tube_spar import TubeSpar
 
-# pylint: disable=invalid-name
-
 
 class TailBoomAero(Model):
     "Tail Boom Aero Model"

--- a/gpkitmodels/GP/aircraft/tail/tail_tests.py
+++ b/gpkitmodels/GP/aircraft/tail/tail_tests.py
@@ -10,8 +10,6 @@ from gpkitmodels.GP.aircraft.tail.vertical_tail import VerticalTail
 from gpkitmodels.GP.aircraft.wing.boxspar import BoxSpar
 from gpkitmodels.GP.aircraft.wing.wing_test import FlightState
 
-# pylint: disable=no-member
-
 
 def test_htail():
 
@@ -101,7 +99,7 @@ def test_emp():
         ],
     )
 
-    from gpkit import settings
+    from gpkit import settings  # noqa: PLC0415
 
     if settings["default_solver"] == "cvxopt":
         for l in [hbend, vbend]:
@@ -167,7 +165,7 @@ def test_tailboom_mod():
         ],
     )
 
-    from gpkit import settings
+    from gpkit import settings  # noqa: PLC0415
 
     if settings["default_solver"] == "cvxopt":
         for l in [hbend, vbend]:

--- a/gpkitmodels/GP/aircraft/tail/tube_spar.py
+++ b/gpkitmodels/GP/aircraft/tail/tube_spar.py
@@ -6,8 +6,6 @@ from numpy import pi
 from gpkitmodels import g
 from gpkitmodels.GP.materials import CFRPFabric
 
-# pylint: disable=invalid-name
-
 
 class TubeSpar(Model):
     "Tail Boom Model"

--- a/gpkitmodels/GP/aircraft/wing/boxspar.py
+++ b/gpkitmodels/GP/aircraft/wing/boxspar.py
@@ -8,8 +8,6 @@ from gpkitmodels.GP.materials import CFRPUD, CFRPFabric, FoamHD
 from .gustloading import GustL
 from .sparloading import SparLoading
 
-# pylint: disable=invalid-name
-
 
 class BoxSpar(Model):
     "Box Spar Model"

--- a/gpkitmodels/GP/aircraft/wing/capspar.py
+++ b/gpkitmodels/GP/aircraft/wing/capspar.py
@@ -8,8 +8,6 @@ from gpkitmodels.GP.materials import CFRPUD, CFRPFabric, FoamHD
 from .gustloading import GustL
 from .sparloading import SparLoading
 
-# pylint: disable=invalid-name
-
 
 class CapSpar(Model):
     "Cap Spar Model"

--- a/gpkitmodels/GP/aircraft/wing/gustloading.py
+++ b/gpkitmodels/GP/aircraft/wing/gustloading.py
@@ -11,8 +11,6 @@ from gpkitmodels.tools.fit_constraintset import FitCS
 
 from .sparloading import SparLoading
 
-# pylint: disable=invalid-name
-
 
 class GustL(SparLoading):
     "Gust Loading Model"

--- a/gpkitmodels/GP/aircraft/wing/sparloading.py
+++ b/gpkitmodels/GP/aircraft/wing/sparloading.py
@@ -3,8 +3,6 @@
 from gpkit import Model, Var, VectorVariable
 from numpy import pi
 
-# pylint: disable=invalid-name
-
 
 class SparLoading(Model):
     "Spar Loading Model"

--- a/gpkitmodels/GP/aircraft/wing/tube_spar.py
+++ b/gpkitmodels/GP/aircraft/wing/tube_spar.py
@@ -30,7 +30,7 @@ class TubeSpar(Model):
             cave * tau >= d,
             4 * I**2 / A**2 / (d / 2) ** 2 + A / pi <= (d / 2) ** 2,
             Sy * (d / 2) <= I,
-            E == E,
+            E == E,  # noqa: PLR0124 (see gpkit-models#30)
         ]
 
         return constraints

--- a/gpkitmodels/GP/aircraft/wing/wing.py
+++ b/gpkitmodels/GP/aircraft/wing/wing.py
@@ -13,8 +13,6 @@ from .capspar import CapSpar
 from .wing_core import WingCore
 from .wing_skin import WingSkin
 
-# pylint: disable=invalid-name
-
 
 class Planform(Model):
     "Planform Area Definition"

--- a/gpkitmodels/GP/aircraft/wing/wing_test.py
+++ b/gpkitmodels/GP/aircraft/wing/wing_test.py
@@ -33,7 +33,7 @@ def wing_test():
     loading.append(W.spar.gustloading(W, fs))
     loading[1].substitutions["W"] = 100
 
-    from gpkit import settings
+    from gpkit import settings  # noqa: PLC0415
 
     if settings["default_solver"] == "cvxopt":
         for l in loading:
@@ -73,7 +73,7 @@ def box_spar():
     loading.append(W.spar.gustloading(W, fs))
     loading[1].substitutions["W"] = 100
 
-    from gpkit import settings
+    from gpkit import settings  # noqa: PLC0415
 
     if settings["default_solver"] == "cvxopt":
         for l in loading:

--- a/gpkitmodels/GP/beam/beam.py
+++ b/gpkitmodels/GP/beam/beam.py
@@ -2,8 +2,6 @@
 
 from gpkit import Model, Variable, Vectorize
 
-# pylint: disable=invalid-name
-
 
 class Beam(Model):
     """discretized beam bending model

--- a/gpkitmodels/SP/SimPleAC/SimPleAC_mission.py
+++ b/gpkitmodels/SP/SimPleAC/SimPleAC_mission.py
@@ -115,7 +115,7 @@ class Fuselage(Model):
 
 
 class FuselageP(Model):
-    def setup(self, fuselage, state):
+    def setup(self, fuselage, state):  # noqa: ARG002
         # Constants
         Cfref = Variable(
             "C_{f_{fuse,ref}}",
@@ -191,7 +191,7 @@ class Wing(Model):
 
 
 class WingP(Model):
-    def setup(self, wing, state):
+    def setup(self, wing, state):  # noqa: ARG002
         self.wing = wing
         # Free Variables
         C_D_ind = Variable("C_{D_{ind}}", "-", "wing induced drag coefficient")

--- a/gpkitmodels/SP/aircraft/prop/dae51polars/dae51_polarfits.py
+++ b/gpkitmodels/SP/aircraft/prop/dae51polars/dae51_polarfits.py
@@ -91,7 +91,7 @@ def return_fit(cl, re):
     return cd
 
 
-def plot_fits(re, cnstr, x, y):
+def plot_fits(re, cnstr, x, y):  # noqa: ARG001 (see gpkit-models#30)
     "plot fit compared to data"
     # colors = ["k", "m", "b", "g", "y"]
     colors = ["#084081", "#0868ac", "#2b8cbe", "#4eb3d3", "#7bccc4"]

--- a/gpkitmodels/SP/aircraft/wing/boxspar.py
+++ b/gpkitmodels/SP/aircraft/wing/boxspar.py
@@ -4,8 +4,6 @@ from gpkit import SignomialsEnabled, VectorVariable
 
 from gpkitmodels.GP.aircraft.wing.boxspar import BoxSpar as BoxSparGP
 
-# pylint: disable=invalid-name
-
 
 class BoxSpar(BoxSparGP):
     "Box Spar Model"

--- a/gpkitmodels/SP/aircraft/wing/wing.py
+++ b/gpkitmodels/SP/aircraft/wing/wing.py
@@ -5,8 +5,6 @@ from gpkit import SignomialsEnabled, Var
 
 from gpkitmodels.GP.aircraft.wing.wing import Wing as WingGP
 
-# pylint: disable=invalid-name
-
 
 class Wing(WingGP):
     "SP wing model"

--- a/gpkitmodels/__init__.py
+++ b/gpkitmodels/__init__.py
@@ -8,4 +8,4 @@ from .tools.modular import PerformanceModel, PhysicalComponent
 
 g = Variable("g", 9.81, "m/s^2", "earth surface gravitational acceleration")
 
-__all__ = (PerformanceModel, PhysicalComponent)
+__all__ = ("PerformanceModel", "PhysicalComponent")

--- a/gpkitmodels/tools/fit_constraintset.py
+++ b/gpkitmodels/tools/fit_constraintset.py
@@ -10,10 +10,6 @@ from gpkit import (
 from numpy import abs as nabs
 from numpy import amax, array, hstack, where
 
-# pylint: disable=too-many-instance-attributes, too-many-locals,
-# pylint: disable=too-many-branches, no-member, import-error
-# pylint: disable=too-many-arguments
-
 
 class FitCS(ConstraintSet):
     """Constraint set for fitted functions
@@ -31,7 +27,7 @@ class FitCS(ConstraintSet):
 
     """
 
-    def __init__(self, fitdata, ivar=None, dvars=None, name="", err_margin=None):
+    def __init__(self, fitdata, ivar=None, dvars=None, name="", err_margin=None):  # noqa: PLR0912
 
         self.fitdata = fitdata
 
@@ -70,7 +66,7 @@ class FitCS(ConstraintSet):
         elif err_margin is None:
             self.mfac = Variable("m_{fac-" + name + "-fit}", 1.0, "-", "fit factor")
         else:
-            raise ValueError("Invalid name for err_margin: valid inputs Max, " "RMS")
+            raise ValueError("Invalid name for err_margin: valid inputs Max, RMS")
 
         if fitdata["ftype"] == "ISMA":
             # constraint of the form 1 >= c1*u1^exp1*u2^exp2*w^(-alpha) + ....
@@ -93,14 +89,13 @@ class FitCS(ConstraintSet):
                     self.constraint = lhs == rhs
             else:
                 self.constraint = lhs == rhs
-        else:
-            if hasattr(rhs, "shape"):
-                if rhs.ndim > 1:
-                    self.constraint = [(lh >= rh) for lh, rh in zip(lhs, rhs)]
-                else:
-                    self.constraint = lhs >= rhs
+        elif hasattr(rhs, "shape"):
+            if rhs.ndim > 1:
+                self.constraint = [(lh >= rh) for lh, rh in zip(lhs, rhs)]
             else:
                 self.constraint = lhs >= rhs
+        else:
+            self.constraint = lhs >= rhs
 
         self.bounds = {}
         for i, dvar in enumerate(self.dvars):
@@ -114,7 +109,7 @@ class FitCS(ConstraintSet):
 
     def get_dataframe(self):
         "return a pandas DataFrame of fit parameters"
-        import pandas as pd
+        import pandas as pd  # noqa: PLC0415
 
         df = pd.DataFrame(list(self.fitdata.values())).transpose()
         df.columns = list(self.fitdata.keys())
@@ -147,7 +142,8 @@ class FitCS(ConstraintSet):
             if direct:
                 msg = (
                     "Variable %.100s could cause inaccurate result"
-                    " because it is %s" % (dvar, state)
+                    " because it is %s"
+                    % (dvar, state)
                     + " %s bound. Solution is %.4f but"
                     " bound is %.4f" % (direct, amax([num]), bnd)
                 )
@@ -164,7 +160,7 @@ class XfoilFit(FitCS):
 
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         fitdata,
         ivar=None,
@@ -193,7 +189,7 @@ class XfoilFit(FitCS):
         if not self.airfoil:
             return
 
-        from .xfoilWrapper import xfoil_comparison
+        from .xfoilWrapper import xfoil_comparison  # noqa: PLC0415
 
         cl, re = 0.0, 0.0
         for dvar in self.dvars:

--- a/gpkitmodels/tools/ipynb2module.py
+++ b/gpkitmodels/tools/ipynb2module.py
@@ -73,7 +73,7 @@ class NotebookLoader(object):
                         cell.source
                     )
                     # run the code in themodule
-                    exec(code, mod.__dict__)
+                    exec(code, mod.__dict__)  # noqa: S102
         finally:
             self.shell.user_ns = save_user_ns
         return mod

--- a/gpkitmodels/tools/xfoilWrapper.py
+++ b/gpkitmodels/tools/xfoilWrapper.py
@@ -6,7 +6,7 @@ from builtins import range
 import numpy as np
 
 
-def blind_call(topline, cl, Re, M, max_iter=100, pathname="/usr/local/bin/xfoil"):
+def blind_call(topline, cl, Re, M, max_iter=100, pathname="/usr/local/bin/xfoil"):  # noqa: PLR0913
 
     proc = subprocess.Popen([pathname], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
     proc.stdin.write(
@@ -47,12 +47,12 @@ def blind_call(topline, cl, Re, M, max_iter=100, pathname="/usr/local/bin/xfoil"
         return float(cd), float(cl), float(cm), stdout_val
 
 
-def single_cl(
+def single_cl(  # noqa: PLR0913
     CL,
     Re=1e7,
     M=0.0,
     airfoil=[],
-    pathname="/home/ckarcher/Xfoil/bin/./xfoil",
+    pathname="/home/ckarcher/Xfoil/bin/./xfoil",  # noqa: ARG001 (dead, see gpkit-models#30)
     number_of_samples=51,
     sampling_min=-10,
     sampling_max=20,
@@ -83,7 +83,7 @@ def single_cl(
         # x = blind_call(topline, alpha, Re, M)
         try:
             x = blind_call(topline, alpha, Re, M)
-        except Exception:
+        except Exception:  # noqa: BLE001
             x = [1, 1]
         if len(x) == 5:
             cd_calcl.append(x[0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,7 @@ dependencies = [
 [dependency-groups]
 dev = [{include-group = "lint"}, {include-group = "test"}, "pre-commit>=4.0.0"]
 lint = [
-    "isort>=5.12.0",
-    "black>=24.1.0",
-    "pylint>=3.0.0",
-    "flake8>=7.0.0",
+    "ruff>=0.8.0",
 ]
 test = [
     "pytest>=8.0.0",
@@ -50,11 +47,31 @@ artifacts = [
     "gpkitmodels/GP/aircraft/tail/*.csv",
 ]
 
-[tool.black]
-line-length=88
+[tool.ruff]
+target-version = "py311"
+extend-exclude = ["gpkitmodels/misc"]  # unreferenced legacy/reference material, not maintained package code
 
-[tool.isort]
-profile = "black"
+[tool.ruff.lint]
+extend-select = [
+    "I",      # import sorting, replaces isort
+    "PL",     # pylint-parity category (convention/error/refactor/warning), stable rules only
+    "ARG",    # unused-argument family
+    "BLE",    # blind-except (broad-exception-caught)
+    "UP032",  # f-string modernization
+    "S102",   # exec-used
+]
+ignore = [
+    "E741",     # ambiguous-variable-name: physics notation (l=length, I=moment of inertia)
+    "PLR2004",  # magic-value-comparison: noisy, no precedent, revisit later
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Variable() calls have side effects (registering in the model's namespace via
+# NamedVariables) independent of whether the local binding is referenced again;
+# carried forward from the old .flake8 per-file-ignores.
+# Code smell, tracked in https://github.com/beautifulmachines/gpkit-models/issues/29
+"gpkitmodels/SP/SimPleAC/SimPleAC_mission.py" = ["F841"]
+"gpkitmodels/GP/aircraft/fuselage/fuselage_profile_drag/fusedragfit.py" = ["F841"]
 
 [tool.pytest.ini_options]
 testpaths = ["gpkitmodels", "tests"]


### PR DESCRIPTION
## Summary
- Replace isort/black/pylint/flake8 with ruff (formatting + linting)
- Enable ruff categories `I`, `PL`, `ARG`, `BLE`, plus `UP032`/`S102`, matching gpkit-core's migration
- Exclude `gpkitmodels/misc/` (unreferenced legacy content)
- Enable `make lint` in CI (previously disabled)
- Fix a real bug: `__all__` in `gpkitmodels/__init__.py` held class objects instead of strings
- File #29 and #30 for pre-existing smells/bugs surfaced along the way, rather than fixing or silently ignoring them

## Test plan
- [x] `make lint` passes
- [x] `make format` is a no-op
- [x] `uv run pytest -v` — 13 passed, 2 skipped