### PR TITLE
derive versions automatically from git tags

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-tags: true  # needed so hatch-vcs can resolve a version from git tags
     - name: Set up uv
       uses: astral-sh/setup-uv@v4
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref }}  # check out by tag name, not bare SHA (actions/checkout#1467)
+        fetch-tags: true  # needed so hatch-vcs can resolve the release tag into a version
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-tags: true  # needed so hatch-vcs can resolve a version from git tags
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean check-clean test coverage lint format
+.PHONY: clean check-clean test coverage lint format release
 
 # Code quality
 lint:
@@ -33,6 +33,24 @@ check-clean:
 		echo "Working directory is clean."; \
 	fi
 
+# Releasing
+release: check-clean  # Cut a release: make release V=x.y.z
+	@if [ -z "$(V)" ]; then \
+		echo "Usage: make release V=x.y.z"; \
+		exit 1; \
+	fi
+	@echo "$(V)" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$$' || { \
+		echo "V must look like x.y.z (got '$(V)')"; \
+		exit 1; \
+	}
+	@git fetch origin main --quiet
+	@if [ "$$(git rev-parse HEAD)" != "$$(git rev-parse origin/main)" ]; then \
+		echo "HEAD is not up to date with origin/main. Pull or push first."; \
+		exit 1; \
+	fi
+	gh release create v$(V) --generate-notes
+
+
 # Help
 help:
 	@echo "Available commands:"
@@ -42,4 +60,5 @@ help:
 	@echo "  coverage          Run tests with coverage reporting"
 	@echo "  clean             Clean build artifacts"
 	@echo "  check-clean       Check no uncommitted changes"
+	@echo "  release           Cut a release (make release V=x.y.z)"
 	@echo "  help              Show this help message"

--- a/README.md
+++ b/README.md
@@ -26,3 +26,33 @@ This repository contains those GP-/SP-compatible models that we consider well do
   * Atmosphere
     * [Tony Tao's fits as (efficient) signomial equalities](https://github.com/beautifulmachines/gpkit-models/blob/main/gpkitmodels/SP/atmosphere/atmosphere.py). Valid until 10,000m of altitude. 
 
+## Releasing
+
+Versions are derived automatically from git tags (via `hatch-vcs`) — there is no
+`__version__` to hand-edit and no version-bump PR to remember. `gpkitmodels.__version__`
+reflects whatever tag is checked out:
+
+- On a commit exactly at tag `v0.2.0`, with no local changes: `0.2.0`.
+- On any other commit: `0.2.1.devN+g<hash>`, where `N` is commits since the last tag.
+- With uncommitted local changes: the version always carries a dev/dirty suffix, even
+  if `HEAD` is itself tagged — so a clean `X.Y.Z` version only ever comes from a
+  committed, exactly-tagged commit.
+
+To cut a release:
+
+```bash
+make release V=0.2.0
+```
+
+or directly:
+
+```bash
+gh release create v0.2.0 --generate-notes
+```
+
+Publishing the release triggers `.github/workflows/publish.yml`, which builds the
+package (version read straight from the new tag) and uploads it to PyPI.
+
+Use plain `vMAJOR.MINOR.PATCH` tags. Bump PATCH for fixes, MINOR for backwards-compatible
+additions, MAJOR for breaking changes.
+

--- a/gpkitmodels/__init__.py
+++ b/gpkitmodels/__init__.py
@@ -1,6 +1,12 @@
 """GPkit Models - Library of exponential cone compatible sizing models"""
 
-__version__ = "0.1.8"
+from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+try:
+    __version__ = _pkg_version("gpkit-models")
+except _PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"
 
 from gpkit import Variable
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -32,7 +32,10 @@ test = [
 Homepage = "https://www.github.com/beautifulmachines/gpkit-models"
 
 [tool.hatch.version]
-path = "gpkitmodels/__init__.py"
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+fallback_version = "0.0.0"
 
 [tool.hatch.build.targets.wheel]
 packages = ["gpkitmodels"]


### PR DESCRIPTION
## Summary
- Bring gpkit-models' version/release mechanism in line with gpkit-core's (beautifulmachines/gpkit-core#91): switch to `hatch-vcs` so the version is derived from git tags instead of a hand-edited `__version__` literal that had already drifted ahead of the last tag (`__init__.py` said `0.1.8`, last tag was `v0.1.7`).
- Fix `publish.yml`/`tests.yml`/`lint.yml` checkout steps so tags are visible to hatch-vcs in CI, including the actions/checkout#1467 SHA-vs-tag fetch conflict fix for the release-triggered publish workflow.
- Add a `make release V=x.y.z` target and a Releasing section in the README (matching tradespace's `V=` argument convention).

## Test plan
- [x] `uv sync` / `uv run python -c "import gpkitmodels; print(gpkitmodels.__version__)"` resolves a correct git-derived version
- [x] `uv run pytest -q` — 13 passed, 2 skipped
- [x] `uv run ruff check .` — clean
- [x] Guard clauses in `make release` verified locally (missing V, bad format, dirty tree) without cutting a real release